### PR TITLE
Simplify the container build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,10 @@ Prerequisites:
 * [gcloud CLI](https://cloud.google.com/sdk/gcloud)
 * Docker
 
-Build ZetaSQL Toolkit
-```
-git clone https://github.com/GoogleCloudPlatform/bigquery-antipattern-recognition.git
-cd bigquery-antipattern-recognition
-(cd zetasql-toolkit-core && mvn clean)
-(cd zetasql-toolkit-core &&  mvn install)
-```
 
 Build utility
 ```
-cd bigquery-antipattern-recognition
-mvn clean
-mvn install -DskipTests
-mvn compile jib:dockerBuild -DskipTests
+mvn clean package jib:dockerBuild -DskipTests
 ```
 
 Run simple inline query
@@ -157,7 +147,7 @@ In order to deploy the tool to Cloud Run Jobs, you'll need to:
     ``` bash
     gcloud auth configure-docker $REGION-docker.pkg.dev
 
-    mvn clean compile jib:build \
+    mvn clean package jib:build \
         -DskipTests \
         -Djib.to.image=$CONTAINER_IMAGE
     ```

--- a/bigquery-antipattern-recognition/pom.xml
+++ b/bigquery-antipattern-recognition/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <zetasql.toolkit.version>0.2.1</zetasql.toolkit.version>
-        <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
+        <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
         <container.mainClass/>
     </properties>
 

--- a/bigquery-antipattern-recognition/pom.xml
+++ b/bigquery-antipattern-recognition/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.google.zetasql.toolkit</groupId>
+    <groupId>com.google.cloud.tools</groupId>
     <artifactId>bigquery-antipattern-recognition</artifactId>
     <version>0.1.1-SNAPSHOT</version>
 
@@ -101,7 +101,7 @@ limitations under the License.
                     </to>
                 </configuration>
                 <groupId>com.google.cloud.tools</groupId>
-                <version>3.2.1</version>
+                <version>${google.cloud.jib.version}</version>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
+        <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@ limitations under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.google.zetasql</groupId>
-    <artifactId>zetasql-helper</artifactId>
+    <groupId>com.google.cloud.tools</groupId>
+    <artifactId>bigquery-antipattern-recognition-tool</artifactId>
     <version>0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -33,7 +33,7 @@ limitations under the License.
 
     <modules>
         <module>zetasql-toolkit-core</module>
-        <module>zetasql-toolkit-examples</module>
+        <module>bigquery-antipattern-recognition</module>
     </modules>
 
     <build>

--- a/zetasql-toolkit-core/pom.xml
+++ b/zetasql-toolkit-core/pom.xml
@@ -16,7 +16,7 @@
         <zetasql.version>2023.04.1</zetasql.version>
         <antlr4.version>4.12.0</antlr4.version>
         <google.cloud.libraries.version>26.11.0</google.cloud.libraries.version>
-        <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
+        <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.2.0</mockito.version>
         <artifactregistry.repository/>

--- a/zetasql-toolkit-examples/pom.xml
+++ b/zetasql-toolkit-examples/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <zetasql.toolkit.version>0.1.1-SNAPSHOT</zetasql.toolkit.version>
-        <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
+        <google.cloud.jib.version>3.3.2</google.cloud.jib.version>
         <container.mainClass/>
     </properties>
 


### PR DESCRIPTION
Properly configures the project's root pom file to include the `bigquery-antipattern-recognition` module. The project can now be built directly using a single maven command at the root, instead of having to build the different modules separately.

Updates README accordingly.