### PR TITLE
Enabling parsing of SQLs with the QUALIFY keyword

### DIFF
--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/Main.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/Main.java
@@ -133,6 +133,7 @@ public class Main {
     LanguageOptions languageOptions = new LanguageOptions();
     languageOptions.enableMaximumLanguageFeatures();
     languageOptions.setSupportsAllStatementKinds();
+    languageOptions.enableReservableKeyword("QUALIFY");
     return languageOptions;
   }
 


### PR DESCRIPTION
While parsing queries with the `QUALIFY` keyword, failing with the following trace :
```
com.google.zetasql.SqlException: QUALIFY clause must be used in conjunction with WHERE or GROUP BY or HAVING clause
	at com.google.zetasql.Parser.parseStatement(Parser.java:47)
	at com.google.zetasql.toolkit.antipattern.parser.Main.getRecommendations(Main.java:141)
	at com.google.zetasql.toolkit.antipattern.parser.Main.main(Main.java:78)
Caused by: com.google.zetasql.io.grpc.StatusRuntimeException: INVALID_ARGUMENT: QUALIFY clause must be used in conjunction with WHERE or GROUP BY or HAVING clause
	at com.google.zetasql.io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:262)
	at com.google.zetasql.io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:243)
	at com.google.zetasql.io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:156)
	at com.google.zetasql.ZetaSqlLocalServiceGrpc$ZetaSqlLocalServiceBlockingStub.parse(ZetaSqlLocalServiceGrpc.java:1576)
	at com.google.zetasql.Parser.parseStatement(Parser.java:44)
	... 2 more
```

With this change parsing SQLs with the `QUALIFY` keyword is successful.
