### PR TITLE
Analyzing information_schema based on window: startTime and endTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ Must be set along with `--read_from_info_schema`. <br>
 Defaults to 1.
 </ul>
 
+`--read_from_info_schema_start_time="start-timestamp"` <br>
+`--read_from_info_schema_end_time="end-timestamp"`
+<ul>
+Alternative to `read_from_info_schema_days` option,<br>
+to specify start and end date or timestamp of INFORMATION_SCHEMA to read.<br>
+Must be set along with `--read_from_info_schema`. <br>
+Defaults to `--read_from_info_schema_days` option.
+</ul>
+
+`--read_from_info_schema_timeout_in_secs=n`
+<ul>
+Specifies timeout, in secs, to query INFORMATION SCHEMA<br>
+Must be set along with `--read_from_info_schema`. <br>
+Defaults to 60.
+</ul>
+
 ``--info_schema_table_name" \`region-us\`.INFORMATION_SCHEMA.JOBS" \``
 <ul>
 Specifies what variant of INFORMATION_SCHEMA.JOBS to read from.

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/cmd/BQAntiPatternCMDParser.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/cmd/BQAntiPatternCMDParser.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.cli.*;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,9 @@ public class BQAntiPatternCMDParser {
   public static final String OUTPUT_FILE_OPTION_NAME = "output_file_path";
   public static final String READ_FROM_INFO_SCHEMA_FLAG_NAME = "read_from_info_schema";
   public static final String READ_FROM_INFO_SCHEMA_DAYS_OPTION_NAME = "read_from_info_schema_days";
+  public static final String READ_FROM_INFO_SCHEMA_START_TIME_OPTION_NAME = "read_from_info_schema_start_time";
+  public static final String READ_FROM_INFO_SCHEMA_END_TIME_OPTION_NAME = "read_from_info_schema_end_time";
+  public static final String READ_FROM_INFO_SCHEMA_TIMEOUT_IN_SECS_OPTION_NAME = "read_from_info_schema_timeout_in_secs";
   public static final String INFO_SCHEMA_MIN_SLOTMS="info_schema_min_slotms";
   public static final String READ_FROM_INFO_SCHEMA_TABLE_OPTION_NAME = "info_schema_table_name";
   public static final String PROCESSING_PROJECT_ID_OPTION_NAME = "processing_project_id";
@@ -170,14 +174,41 @@ public class BQAntiPatternCMDParser {
             .build();
     options.addOption(infoSchemaDays);
 
-    Option infoSchemaSlotmsMin =
-        Option.builder(INFO_SCHEMA_MIN_SLOTMS)
-                .argName(INFO_SCHEMA_MIN_SLOTMS)
+    Option infoSchemaStartTime =
+        Option.builder(READ_FROM_INFO_SCHEMA_START_TIME_OPTION_NAME)
+                .argName(READ_FROM_INFO_SCHEMA_START_TIME_OPTION_NAME)
                 .hasArg()
                 .required(false)
-                .desc("Specifies the minimum number of slotms for a query in INFORMATION_SCHEMA to be" +
-                        "selected for processing. Defaults to 0 (all queries are processed)")
+                .desc("Specifies start timestamp INFORMATION SCHEMA be queried for")
                 .build();
+    options.addOption(infoSchemaStartTime);
+
+    Option infoSchemaEndTime =
+        Option.builder(READ_FROM_INFO_SCHEMA_END_TIME_OPTION_NAME)
+                .argName(READ_FROM_INFO_SCHEMA_END_TIME_OPTION_NAME)
+                .hasArg()
+                .required(false)
+                .desc("Specifies end timestamp INFORMATION SCHEMA be queried for")
+                .build();
+    options.addOption(infoSchemaEndTime);
+
+    Option infoSchemaTimeoutSecs =
+        Option.builder(READ_FROM_INFO_SCHEMA_TIMEOUT_IN_SECS_OPTION_NAME)
+                .argName(READ_FROM_INFO_SCHEMA_TIMEOUT_IN_SECS_OPTION_NAME)
+                .hasArg()
+                .required(false)
+                .desc("Specifies timeout (in secs) to query INFORMATION SCHEMA")
+                .build();
+    options.addOption(infoSchemaTimeoutSecs);
+
+    Option infoSchemaSlotmsMin =
+            Option.builder(INFO_SCHEMA_MIN_SLOTMS)
+                    .argName(INFO_SCHEMA_MIN_SLOTMS)
+                    .hasArg()
+                    .required(false)
+                    .desc("Specifies the minimum number of slotms for a query in INFORMATION_SCHEMA to be" +
+                            "selected for processing. Defaults to 0 (all queries are processed)")
+                    .build();
     options.addOption(infoSchemaSlotmsMin);
 
     Option infoSchemaTable =
@@ -235,7 +266,11 @@ public class BQAntiPatternCMDParser {
     String infoSchemaDays = cmd.getOptionValue(READ_FROM_INFO_SCHEMA_DAYS_OPTION_NAME);
     String infoSchemaTableName = cmd.getOptionValue(READ_FROM_INFO_SCHEMA_TABLE_OPTION_NAME);
     String infoSchemaSlotmsMin = cmd.getOptionValue(INFO_SCHEMA_MIN_SLOTMS);
-    return new InformationSchemaQueryIterable(processingProjectId, infoSchemaDays, infoSchemaTableName, infoSchemaSlotmsMin);
+    String timeoutInSecs = cmd.getOptionValue(READ_FROM_INFO_SCHEMA_TIMEOUT_IN_SECS_OPTION_NAME);
+    String infoSchemaStartTime = cmd.getOptionValue(READ_FROM_INFO_SCHEMA_START_TIME_OPTION_NAME);
+    String infoSchemaEndTime = cmd.getOptionValue(READ_FROM_INFO_SCHEMA_END_TIME_OPTION_NAME);
+
+    return new InformationSchemaQueryIterable(processingProjectId, infoSchemaDays, infoSchemaStartTime, infoSchemaEndTime, infoSchemaTableName, infoSchemaSlotmsMin, timeoutInSecs);
   }
 
   public static Iterator<InputQuery> buildIteratorFromQueryStr(String queryStr) {

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/cmd/InformationSchemaQueryIterable.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/cmd/InformationSchemaQueryIterable.java
@@ -19,7 +19,11 @@ package com.google.zetasql.toolkit.antipattern.cmd;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.TableResult;
 import com.google.zetasql.toolkit.antipattern.util.BigQueryHelper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+
 import java.util.Iterator;
+import java.util.Optional;
 
 public class InformationSchemaQueryIterable implements Iterator<InputQuery> {
 
@@ -27,18 +31,21 @@ public class InformationSchemaQueryIterable implements Iterator<InputQuery> {
   String IS_TABLE_DEFAULT = "`region-us`.INFORMATION_SCHEMA.JOBS";
   String DAYS_BACK_DEFAULT = "30";
   Integer SLOTMS_MIN_DEFAULT = 0;
+  Long TIMEOUT_SECS_DEFAULT = 60L;
 
 
-  public InformationSchemaQueryIterable(String projectId, String customDaysBack, String customISTable,
-                                        String infoSchemaSlotmsMin)
+  public InformationSchemaQueryIterable(String projectId, String customDaysBack, String startTime, String endTime, String customISTable,
+                                        String infoSchemaSlotmsMin, String customTimeoutInSecs)
           throws InterruptedException {
 
     String daysBack = customDaysBack == null ? DAYS_BACK_DEFAULT : customDaysBack;
     String ISTable = customISTable == null ? IS_TABLE_DEFAULT : customISTable;
     Integer slotsMsMin = infoSchemaSlotmsMin == null ? SLOTMS_MIN_DEFAULT : Integer.parseInt(infoSchemaSlotmsMin);
+    Long timeoutInSecs = !NumberUtils.isParsable(customTimeoutInSecs) ? TIMEOUT_SECS_DEFAULT : Long.parseLong(customTimeoutInSecs);
 
     TableResult tableResult =
-        BigQueryHelper.getQueriesFromIS(projectId, daysBack, ISTable, slotsMsMin);
+        BigQueryHelper.getQueriesFromIS(projectId, daysBack, startTime, endTime, ISTable, slotsMsMin, timeoutInSecs);
+
     fieldValueListIterator = tableResult.iterateAll().iterator();
   }
 

--- a/bigquery-antipattern-recognition/src/test/java/com/google/zetasql/toolkit/antipattern/cmd/BQAntiPattenCMDParserTest.java
+++ b/bigquery-antipattern-recognition/src/test/java/com/google/zetasql/toolkit/antipattern/cmd/BQAntiPattenCMDParserTest.java
@@ -1,0 +1,70 @@
+package com.google.zetasql.toolkit.antipattern.cmd;
+
+import org.apache.commons.cli.ParseException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class BQAntiPattenCMDParserTest {
+    private final String args[];
+    private final boolean shouldFail;
+    private final String errorMessage;
+
+    public BQAntiPattenCMDParserTest(String args[], boolean shouldFail, String errorMessage) {
+        this.args =  args;
+        this.shouldFail = shouldFail;
+        this.errorMessage = errorMessage;
+    }
+    @Parameterized.Parameters
+    public static Collection primeNumbers() {
+        return Arrays.asList(new Object[][] {
+                { new String[0], false, null},
+                { new String[] {"--random_option"}, true, "Unrecognized option: --random_option"},
+                { new String[] {
+                        "--read_from_info_schema",
+                        "--read_from_info_schema_days", "4",
+                        "--info_schema_table_name", "`region-us`.INFORMATION_SCHEMA.JOBS",
+                        "--processing_project_id", "a-gcp-project-for-analysis",
+                        "--output_table", "a-gcp-project-for-analysis.bq_recommendations.antipattern_output_table"
+                }, false, null},
+                { new String[] {
+                        "--read_from_info_schema",
+                        "--read_from_info_schema_start_time", "'2023-08-15'",
+                        "--read_from_info_schema_end_time", "'2023-08-16'",
+                        "--read_from_info_schema_timeout_in_secs", "60",
+                        "--info_schema_table_name", "`region-us`.INFORMATION_SCHEMA.JOBS",
+                        "--processing_project_id", "a-gcp-project-for-analysis",
+                        "--output_table", "a-gcp-project-for-analysis.bq_recommendations.antipattern_output_table"
+                }, false, null},
+                { new String[] {
+                        "--read_from_info_schema_start_time",
+                }, true, "Missing argument for option: read_from_info_schema_start_time"},
+                { new String[] {
+                        "--read_from_info_schema_end_time",
+                }, true, "Missing argument for option: read_from_info_schema_end_time"},
+                { new String[] {
+                        "--read_from_info_schema_timeout_in_secs",
+                }, true, "Missing argument for option: read_from_info_schema_timeout_in_secs"},
+        });
+    }
+    @Test
+    public void testMethod() {
+        try {
+            new BQAntiPatternCMDParser(args);
+            if (shouldFail) {
+                Assert.fail("parsing should fail, but did not fail, for args: " + Arrays.toString(args));
+            }
+        } catch (ParseException e) {
+            if (shouldFail) {
+                Assert.assertEquals(this.errorMessage, e.getMessage());
+            } else {
+                Assert.fail(e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
with these command line options:
```bash
--read_from_info_schema 
--read_from_info_schema_start_time "2023-08-15 09:00:00" 
--read_from_info_schema_end_time "2023-08-16"
--read_from_info_schema_timeout_in_secs 60  
--info_schema_table_name `region-us`.INFORMATION_SCHEMA.JOBS 
--processing_project_id <my-project>
--output_table <my-project>.<my-dataset>.antipattern_output_table
```

Query on INFORMATION SCHEMA:
```sql
SELECT
  project_id,
  CONCAT(project_id, ":US.",  job_id) job_id, 
  query, 
  total_slot_ms / (1000 * 60 * 60 ) AS slot_hours, 
  user_email 
FROM
`region-us`.INFORMATION_SCHEMA.JOBS
WHERE 
  creation_time BETWEEN '2023-08-15 09:00:00' AND '2023-08-16'
  AND total_slot_ms > 0
  AND (statement_type != "SCRIPT" OR statement_type IS NULL)
  AND (reservation_id != 'default-pipeline' or reservation_id IS NULL)
  AND query not like '%INFORMATION_SCHEMA%' 
ORDER BY 
  project_id, start_time desc
```