### PR TITLE
Enable "recursive" detection in GCS

### DIFF
--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/GCSHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/GCSHelper.java
@@ -43,8 +43,7 @@ public class GCSHelper {
     Page<Blob> blobs =
         storage.list(
             bucketName,
-            Storage.BlobListOption.prefix(prefix),
-            Storage.BlobListOption.currentDirectory());
+            Storage.BlobListOption.prefix(prefix));
 
     for (Blob blob : blobs.iterateAll()) {
       String blobName = blob.getName();

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/GCSHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/GCSHelper.java
@@ -47,7 +47,7 @@ public class GCSHelper {
 
     for (Blob blob : blobs.iterateAll()) {
       String blobName = blob.getName();
-      if (!blobName.equals(prefix)) {
+      if (!blobName.equals(prefix) && blobName.matches(".*\\.sql$")) {
         gcsFileList.add(GCS_PATH_PREFIX + bucketName + GCS_DELIMITER + blobName);
       }
     }


### PR DESCRIPTION
Removing the current directory parameter allows this function to return all SQL files in the bucket rather than only the ones in one directory. 

See this [link](https://github.com/googleapis/java-storage/blob/HEAD/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithPrefix.java#L45-L49) for an example