### PR TITLE
Fixed a bug that caused an error when Japanese characters were included in a query.

### DIFF
--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/ZetaSQLStringParsingHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/ZetaSQLStringParsingHelper.java
@@ -16,6 +16,7 @@
 
 package com.google.zetasql.toolkit.antipattern.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,12 +35,30 @@ public class ZetaSQLStringParsingHelper {
   }
 
   public static int countLine(String query, int start) {
+    byte[] utf8Bytes = query.getBytes(StandardCharsets.UTF_8);
+
+    int utf16Index = 0;
+    int byteIndex = 0;
+    while (byteIndex < start && byteIndex < utf8Bytes.length) {
+      int currentByte = utf8Bytes[byteIndex] & 0xFF;
+      if (currentByte < 0x80) {
+        byteIndex++;
+      } else if (currentByte < 0xE0) {
+        byteIndex += 2;
+      } else if (currentByte < 0xF0) {
+        byteIndex += 3;
+      } else {
+        byteIndex += 4;
+      }
+      utf16Index++;
+    }
+
     int count = 0;
-    for (int i = 0; i < start; i++) {
+    for (int i = 0; i < utf16Index; i++) {
       if (query.charAt(i) == '\n') {
         count++;
       }
     }
-    return count+1;
+    return count + 1;
   }
 }


### PR DESCRIPTION
1. About
There is an error when I scan a BigQuery SQL containing Japanese.

2. How to reproduce it
The error occurred when I parsed this code.
```
 --日本語ああああああああああああああああ
SELECT
  title,
  language
FROM `bigquery-public-data.samples.wikipedia`
WHERE REGEXP_CONTAINS(title, '.*aaaaa.*')
```

The error is:
```
ERROR com.google.zetasql.toolkit.antipattern.util.AntiPatternHelper - index 138,length 138
java.lang.StringIndexOutOfBoundsException: index 138,length 138
        at java.base/java.lang.String.checkIndex(String.java:3278)
        at java.base/java.lang.StringUTF16.checkIndex(StringUTF16.java:1470)
        at java.base/java.lang.StringUTF16.charAt(StringUTF16.java:1267)
        at java.base/java.lang.String.charAt(String.java:695)
        at com.google.zetasql.toolkit.antipattern.util.ZetaSQLStringParsingHelper.countLine(ZetaSQLStringParsingHelper.java:67)
        at com.google.zetasql.toolkit.antipattern.parser.visitors.IdentifyRegexpContainsVisitor.visit(IdentifyRegexpContainsVisitor.java:63)
        at com.google.zetasql.parser.ASTNodes$ASTFunctionCall.accept(ASTNodes.java:3592)
        at com.google.zetasql.parser.ParseTreeVisitor.descend(ParseTreeVisitor.java:45)
        at com.google.zetasql.parser.ASTNodes$ASTWhereClause.acceptChildren(ASTNodes.java:1567)
        at com.google.zetasql.parser.ParseTreeVisitor.defaultVisit(ParseTreeVisitor.java:36)
        at com.google.zetasql.parser.ParseTreeVisitor.visit(ParseTreeVisitor.java:98)
        at com.google.zetasql.parser.ASTNodes$ASTWhereClause.accept(ASTNodes.java:1561)
        at com.google.zetasql.parser.ParseTreeVisitor.descend(ParseTreeVisitor.java:45)
        at com.google.zetasql.parser.ASTNodes$ASTSelect.acceptChildren(ASTNodes.java:618)
        at com.google.zetasql.parser.ParseTreeVisitor.defaultVisit(ParseTreeVisitor.java:36)
        at com.google.zetasql.parser.ParseTreeVisitor.visit(ParseTreeVisitor.java:62)
        at com.google.zetasql.parser.ASTNodes$ASTSelect.accept(ASTNodes.java:607)
        at com.google.zetasql.parser.ParseTreeVisitor.descend(ParseTreeVisitor.java:45)
        at com.google.zetasql.parser.ASTNodes$ASTQuery.acceptChildren(ASTNodes.java:409)
        at com.google.zetasql.parser.ParseTreeVisitor.defaultVisit(ParseTreeVisitor.java:36)
        at com.google.zetasql.parser.ParseTreeVisitor.visit(ParseTreeVisitor.java:58)
        at com.google.zetasql.parser.ASTNodes$ASTQuery.accept(ASTNodes.java:402)
        at com.google.zetasql.parser.ParseTreeVisitor.descend(ParseTreeVisitor.java:45)
        at com.google.zetasql.parser.ASTNodes$ASTQueryStatement.acceptChildren(ASTNodes.java:224)
        at com.google.zetasql.parser.ParseTreeVisitor.defaultVisit(ParseTreeVisitor.java:36)
        at com.google.zetasql.parser.ParseTreeVisitor.visit(ParseTreeVisitor.java:54)
        at com.google.zetasql.parser.ASTNodes$ASTQueryStatement.accept(ASTNodes.java:218)
        at com.google.zetasql.toolkit.antipattern.util.AntiPatternHelper.checkForAntiPatternsInQueryWithParserVisitors(AntiPatternHelper.java:87)
        at com.google.zetasql.toolkit.antipattern.util.AntiPatternHelper.checkForAntiPatternsInQueryWithParserVisitors(AntiPatternHelper.java:74)
        at com.google.zetasql.toolkit.antipattern.Main.executeAntiPatternsInQuery(Main.java:72)
        at com.google.zetasql.toolkit.antipattern.Main.main(Main.java:56)
```

3. Cause of error
The argument start passed to the countLine function in ZetaSQLStringParsingHelper.java is a byte length. Therefore, The error occur when characters with inconsistent byte lengths and character counts, such as Japanese, are entered into the query.

4. Fix
I fixed the countLine function in ZetaSQLStringParsingHelper.java. I made the argument start match the SQL query length. 