### PR TITLE
add NULL check for FROM clause in Multiple CTE antipattern

### DIFF
--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyCTEsEvalMultipleTimesVisitor.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyCTEsEvalMultipleTimesVisitor.java
@@ -84,7 +84,7 @@ public class IdentifyCTEsEvalMultipleTimesVisitor extends ParseTreeVisitor
     } else if (tableExpression instanceof ASTNodes.ASTTableSubquery) {
       ASTNodes.ASTQueryExpression queryExpression =
           ((ASTNodes.ASTTableSubquery) tableExpression).getSubquery().getQueryExpr();
-      if (queryExpression instanceof ASTNodes.ASTSelect) {
+      if (queryExpression instanceof ASTNodes.ASTSelect && ((ASTSelect) queryExpression).getFromClause() != null) {
         ASTNodes.ASTTableExpression tableExpression1 =
             ((ASTSelect) queryExpression).getFromClause().getTableExpression();
         visit(tableExpression1);


### PR DESCRIPTION
This addresses edge cases where CTEs create dummy data and do not have a FROM clause, causing a NULL value exception