### PR TITLE
Zeta toolkit upgrade

### DIFF
--- a/bigquery-antipattern-recognition/pom.xml
+++ b/bigquery-antipattern-recognition/pom.xml
@@ -24,7 +24,7 @@ limitations under the License.
     <version>1.0.0.1</version>
 
     <properties>
-        <java.version>11</java.version> 
+        <java.version>11</java.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -35,7 +35,7 @@ limitations under the License.
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.7.13</version> 
+            <version>2.7.13</version>
          </dependency>
          <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -44,9 +44,9 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>zetasql-toolkit-core</artifactId>
+            <artifactId>zetasql-toolkit-bigquery</artifactId>
             <groupId>com.google.zetasql.toolkit</groupId>
-            <version>0.3.3</version>
+            <version>0.5.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -91,7 +91,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.zetasql</groupId>
             <artifactId>zetasql-client</artifactId>
-            <version>2023.04.1</version>
+            <version>2024.03.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
@@ -143,7 +143,7 @@ limitations under the License.
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.15.0</version>
+                <version>26.43.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
@@ -55,7 +55,7 @@ public class IdentifyRegexpContainsVisitor extends ParseTreeVisitor implements A
         // search for argument with string
         for (ASTNodes.ASTExpression argument : arguments) {
           if (argument instanceof ASTNodes.ASTStringLiteral) {
-            String stringLiteralArg = ((ASTNodes.ASTStringLiteral) argument).getImage();
+            String stringLiteralArg = ((ASTNodes.ASTStringLiteral) argument).getStringValue();
             Pattern pattern = Pattern.compile(REGEX_STRING);
             Matcher matcher = pattern.matcher(stringLiteralArg);
             if (matcher.find()) {

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
@@ -1,15 +1,16 @@
 /*
  * Copyright (C) 2024 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
  */
@@ -21,18 +22,17 @@ import com.google.zetasql.LanguageOptions;
 import com.google.zetasql.Parser;
 import com.google.zetasql.parser.ASTNodes;
 import com.google.zetasql.parser.ParseTreeVisitor;
-import com.google.zetasql.resolvedast.ResolvedNodes;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
-import com.google.zetasql.toolkit.antipattern.analyzer.visitors.joinorder.JoinOrderVisitor;
-import com.google.zetasql.toolkit.antipattern.cmd.InputQuery;
 import com.google.zetasql.toolkit.antipattern.parser.visitors.*;
 import com.google.zetasql.toolkit.antipattern.parser.visitors.rownum.IdentifyLatestRecordVisitor;
 import com.google.zetasql.toolkit.antipattern.parser.visitors.whereorder.IdentifyWhereOrderVisitor;
+import com.google.zetasql.toolkit.antipattern.analyzer.visitors.joinorder.JoinOrderVisitor;
+import com.google.zetasql.toolkit.antipattern.cmd.InputQuery;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryAPIResourceProvider;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
-import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +49,7 @@ public class AntiPatternHelper {
     private final String project;
     private final LanguageOptions languageOptions;
     private final Boolean useAnalizer;
+
     public AntiPatternHelper(String project, Boolean useAnalizer) {
         this.project = project;
         this.useAnalizer = useAnalizer;
@@ -75,18 +76,18 @@ public class AntiPatternHelper {
     }
 
     public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns, List<AntiPatternVisitor> parserVisitorList) {
-        if(this.visitorMetricsMap == null) {
+        if (this.visitorMetricsMap == null) {
             setVisitorMetricsMap(parserVisitorList);
         }
 
         for (AntiPatternVisitor visitorThatFoundAntiPattern : parserVisitorList) {
             logger.info("Parsing query with id: " + inputQuery.getQueryId() +
                     " for anti-pattern: " + visitorThatFoundAntiPattern.getName());
-            ASTNodes.ASTScript parsedQuery = Parser.parseScript( inputQuery.getQuery(), this.languageOptions);
-            try{
+            ASTNodes.ASTScript parsedQuery = Parser.parseScript(inputQuery.getQuery(), this.languageOptions);
+            try {
                 parsedQuery.accept((ParseTreeVisitor) visitorThatFoundAntiPattern);
                 String result = visitorThatFoundAntiPattern.getResult();
-                if(result.length() > 0) {
+                if (result.length() > 0) {
                     visitorsThatFoundAntiPatterns.add(visitorThatFoundAntiPattern);
                     this.visitorMetricsMap.merge(visitorThatFoundAntiPattern.getName(), 1, Integer::sum);
                 }
@@ -108,22 +109,22 @@ public class AntiPatternHelper {
             currentProject = inputQuery.getProjectId();
         }
 
-        BigQueryCatalog catalog = new BigQueryCatalog("");
+        BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("");
         if ((this.analyzerProject == null || !this.analyzerProject.equals(currentProject))) {
             this.analyzerProject = inputQuery.getProjectId();
             catalog = new BigQueryCatalog(this.analyzerProject, this.resourceProvider);
             catalog.addAllTablesUsedInQuery(query, this.analyzerOptions);
         }
         JoinOrderVisitor visitor = new JoinOrderVisitor(this.service);
-        if(this.visitorMetricsMap.get(visitor.getName()) == null) {
-            this.visitorMetricsMap.put(visitor.getName(), 0);
-            this.visitorMetricsMap.merge(visitor.getName(), 1, Integer::sum);
+        if (this.visitorMetricsMap == null) {
+            this.visitorMetricsMap = new HashMap<>();
         }
+        this.visitorMetricsMap.merge(visitor.getName(), 1, Integer::sum);
         try {
             logger.info("Analyzing query with id: " + inputQuery.getQueryId() +
                     " For anti-pattern:" + visitor.getName());
-            Iterator<ResolvedNodes.ResolvedStatement> statementIterator = this.analyzer.analyzeStatements(query, catalog);
-            statementIterator.forEachRemaining(statement -> statement.accept(visitor));
+            Iterator<AnalyzedStatement> statementIterator = this.analyzer.analyzeStatements(query, catalog);
+            statementIterator.forEachRemaining(statement -> statement.getResolvedStatement().get().accept(visitor));
 
             String result = visitor.getResult();
             if (result.length() > 0) {
@@ -150,7 +151,6 @@ public class AntiPatternHelper {
                 new IdentifyWhereOrderVisitor(query),
                 new IdentifyMissingDropStatementVisitor(query),
                 new IdentifyDroppedPersistentTableVisitor(query)
-
         ));
     }
 
@@ -162,15 +162,13 @@ public class AntiPatternHelper {
         return useAnalizer;
     }
 
-    private void setVisitorMetricsMap(List<AntiPatternVisitor> parserVisitorList ) {
+    private void setVisitorMetricsMap(List<AntiPatternVisitor> parserVisitorList) {
         this.visitorMetricsMap = new HashMap<>();
-        parserVisitorList.stream().forEach(visitor -> this.visitorMetricsMap.put(visitor.getName(), 0));
+        parserVisitorList.forEach(visitor -> this.visitorMetricsMap.put(visitor.getName(), 0));
     }
 
     private ZetaSQLToolkitAnalyzer getAnalyzer(AnalyzerOptions options) {
-        LanguageOptions languageOptions = BigQueryLanguageOptions.get().enableMaximumLanguageFeatures();
-        languageOptions.setSupportsAllStatementKinds();
-        options.setLanguageOptions(languageOptions);
+        options.setLanguageOptions(this.languageOptions);
         options.setCreateNewColumnForEachProjectedOutput(true);
         return new ZetaSQLToolkitAnalyzer(options);
     }

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/PrintAnalyzerDebugString.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/PrintAnalyzerDebugString.java
@@ -2,7 +2,7 @@ package com.google.zetasql.toolkit.antipattern.util;
 
 import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.LanguageOptions;
-import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
@@ -69,7 +69,7 @@ public class PrintAnalyzerDebugString {
         + ";";
 
     catalog.addAllTablesUsedInQuery(query, options);
-    Iterator<ResolvedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
+    Iterator<AnalyzedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
     statementIterator.forEachRemaining(System.out::println);
 
   }


### PR DESCRIPTION
Resolves #101 
This pull request includes updates to dependencies, improvements to the `AntiPatternHelper` class, and changes to the handling of analyzed statements. These changes aim to modernize the codebase, enhance functionality, and improve maintainability.

### Dependency Updates:
* Updated the `zetasql-toolkit-core` dependency to `zetasql-toolkit-bigquery` and upgraded its version from `0.3.3` to `0.5.1` in `pom.xml`.
* Upgraded the `zetasql-client` dependency version from `2023.04.1` to `2024.03.1` in `pom.xml`.
* Updated the `libraries-bom` dependency version from `26.15.0` to `26.43.0` in `pom.xml`.

### Code Improvements in `AntiPatternHelper`:
* Replaced `BigQueryCatalog` instantiation with `BigQueryCatalog.usingBigQueryAPI` to improve catalog initialization.
* Simplified the `setVisitorMetricsMap` method by using a cleaner lambda expression.
* Refactored the `getAnalyzer` method to use the existing `languageOptions` field instead of creating new `LanguageOptions`.

### Handling of Analyzed Statements:
* Replaced `ResolvedStatement` with `AnalyzedStatement` in multiple files, including `AntiPatternHelper` and `PrintAnalyzerDebugString`, to align with updated APIs and improve type safety. [[1]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dL111-R127) [[2]](diffhunk://#diff-989acf321946b3469167b6eda25cd6b395a00ed5db52e30cfcfe9f6cbeb9529cL5-R5) [[3]](diffhunk://#diff-989acf321946b3469167b6eda25cd6b395a00ed5db52e30cfcfe9f6cbeb9529cL72-R72)

### Code Cleanup:
* Adjusted import statements in `AntiPatternHelper` to remove unused imports and reorder for clarity.
* Removed unnecessary blank lines and improved formatting for better readability.

### Bug Fix:
* Fixed incorrect method usage in `IdentifyRegexpContainsVisitor` by replacing `getImage()` with `getStringValue()` for accurate string literal handling.