### PR TITLE
fix: update dependencies 

### DIFF
--- a/bigquery-antipattern-recognition/pom.xml
+++ b/bigquery-antipattern-recognition/pom.xml
@@ -44,9 +44,9 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>zetasql-toolkit-core</artifactId>
+            <artifactId>zetasql-toolkit-bigquery</artifactId>
             <groupId>com.google.zetasql.toolkit</groupId>
-            <version>0.3.3</version>
+            <version>0.5.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -91,7 +91,7 @@ limitations under the License.
         <dependency>
             <groupId>com.google.zetasql</groupId>
             <artifactId>zetasql-client</artifactId>
-            <version>2023.04.1</version>
+            <version>2024.03.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
@@ -143,7 +143,7 @@ limitations under the License.
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.15.0</version>
+                <version>26.43.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
@@ -1,19 +1,21 @@
 /*
-* Copyright (C) 2024 Google LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License"); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.zetasql.toolkit.antipattern.parser.visitors;
+
 import com.google.common.collect.ImmutableList;
 import com.google.zetasql.parser.ASTNodes;
 import com.google.zetasql.parser.ParseTreeVisitor;
@@ -70,4 +72,3 @@ public class IdentifyRegexpContainsVisitor extends ParseTreeVisitor implements A
     return NAME;
   }
 }
- 

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
@@ -14,64 +14,62 @@
  * the License.
  */
 
-package com.google.zetasql.toolkit.antipattern.parser.visitors;
+ package com.google.zetasql.toolkit.antipattern.parser.visitors;
 
-import com.google.common.collect.ImmutableList;
-import com.google.zetasql.parser.ASTNodes;
-
-import com.google.zetasql.parser.ParseTreeVisitor;
-import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
-import com.google.zetasql.toolkit.antipattern.util.ZetaSQLStringParsingHelper;
-import java.util.ArrayList;
-import java.util.stream.Collectors;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
-
-public class IdentifyRegexpContainsVisitor extends ParseTreeVisitor implements AntiPatternVisitor {
-
-  public static final String NAME = "StringComparison";
-  private static final String REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE =
-      "REGEXP_CONTAINS at line %d. Prefer LIKE when the full power of regex is not needed (e.g. wildcard matching).";
-  private static final String REGEXP_CONTAINS_FUN_ID_STR = "regexp_contains";
-  private static final String REGEX_STRING = "['\"]\\.\\*.*\\.\\*['\"]";
-  private ArrayList<String> result = new ArrayList<String>();
-  private String query;
-
-  public String getResult() {
-    return result.stream().distinct().collect(Collectors.joining("\n"));
-  }
-
-  public IdentifyRegexpContainsVisitor(String query) {
-    this.query = query;
-  }
-
-  @Override
-  public void visit(ASTNodes.ASTFunctionCall node) {
-    ImmutableList<ASTNodes.ASTIdentifier> identifiers = node.getFunction().getNames();
-    for (ASTNodes.ASTIdentifier identifier : identifiers) {
-      // search for regexp_contains
-      if (identifier.getIdString().toLowerCase().equals(REGEXP_CONTAINS_FUN_ID_STR)) {
-        ImmutableList<ASTNodes.ASTExpression> arguments = node.getArguments();
-        // search for argument with string
-        for (ASTNodes.ASTExpression argument : arguments) {
-          if (argument instanceof ASTNodes.ASTStringLiteral) {
-            String stringLiteralArg = ((ASTNodes.ASTStringLiteral) argument).getImage();
-            Pattern pattern = Pattern.compile(REGEX_STRING);
-            Matcher matcher = pattern.matcher(stringLiteralArg);
-            if (matcher.find()) {
-              int lineNum =
-                  ZetaSQLStringParsingHelper.countLine(
-                      query, identifier.getParseLocationRange().start());
-              result.add(String.format(REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE, lineNum));
-            }
-          }
-        }
-      }
-    }
-  }
-
-  @Override
-  public String getName() {
-    return NAME;
-  }
-}
+ import com.google.common.collect.ImmutableList;
+ import com.google.zetasql.parser.ASTNodes;
+ import com.google.zetasql.parser.ParseTreeVisitor;
+ import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
+ import com.google.zetasql.toolkit.antipattern.util.ZetaSQLStringParsingHelper;
+ import java.util.ArrayList;
+ import java.util.stream.Collectors;
+ import java.util.regex.Pattern;
+ import java.util.regex.Matcher;
+ 
+ public class IdentifyRegexpContainsVisitor extends ParseTreeVisitor implements AntiPatternVisitor {
+ 
+   public static final String NAME = "StringComparison";
+   private static final String REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE = "REGEXP_CONTAINS at line %d. Prefer LIKE when the full power of regex is not needed (e.g. wildcard matching).";
+   private static final String REGEXP_CONTAINS_FUN_ID_STR = "regexp_contains";
+   private static final String REGEX_STRING = "['\"]\\.\\*.*\\.\\*['\"]";
+   private ArrayList<String> result = new ArrayList<String>();
+   private String query;
+ 
+   public String getResult() {
+     return result.stream().distinct().collect(Collectors.joining("\n"));
+   }
+ 
+   public IdentifyRegexpContainsVisitor(String query) {
+     this.query = query;
+   }
+ 
+   @Override
+   public void visit(ASTNodes.ASTFunctionCall node) {
+     ImmutableList<ASTNodes.ASTIdentifier> identifiers = node.getFunction().getNames();
+     for (ASTNodes.ASTIdentifier identifier : identifiers) {
+       // search for regexp_contains
+       if (identifier.getIdString().toLowerCase().equals(REGEXP_CONTAINS_FUN_ID_STR)) {
+         ImmutableList<ASTNodes.ASTExpression> arguments = node.getArguments();
+         // search for argument with string
+         for (ASTNodes.ASTExpression argument : arguments) {
+           if (argument instanceof ASTNodes.ASTStringLiteral) {
+             String stringLiteralArg = ((ASTNodes.ASTStringLiteral) argument).getStringValue();
+             Pattern pattern = Pattern.compile(REGEX_STRING);
+             Matcher matcher = pattern.matcher(stringLiteralArg);
+             if (matcher.find()) {
+               int lineNum = ZetaSQLStringParsingHelper.countLine(
+                   query, identifier.getParseLocationRange().start());
+               result.add(String.format(REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE, lineNum));
+             }
+           }
+         }
+       }
+     }
+   }
+ 
+   @Override
+   public String getName() {
+     return NAME;
+   }
+ }
+ 

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/parser/visitors/IdentifyRegexpContainsVisitor.java
@@ -1,75 +1,73 @@
 /*
- * Copyright (C) 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
+* Copyright (C) 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package com.google.zetasql.toolkit.antipattern.parser.visitors;
+import com.google.common.collect.ImmutableList;
+import com.google.zetasql.parser.ASTNodes;
+import com.google.zetasql.parser.ParseTreeVisitor;
+import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
+import com.google.zetasql.toolkit.antipattern.util.ZetaSQLStringParsingHelper;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
- package com.google.zetasql.toolkit.antipattern.parser.visitors;
+public class IdentifyRegexpContainsVisitor extends ParseTreeVisitor implements AntiPatternVisitor {
 
- import com.google.common.collect.ImmutableList;
- import com.google.zetasql.parser.ASTNodes;
- import com.google.zetasql.parser.ParseTreeVisitor;
- import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
- import com.google.zetasql.toolkit.antipattern.util.ZetaSQLStringParsingHelper;
- import java.util.ArrayList;
- import java.util.stream.Collectors;
- import java.util.regex.Pattern;
- import java.util.regex.Matcher;
- 
- public class IdentifyRegexpContainsVisitor extends ParseTreeVisitor implements AntiPatternVisitor {
- 
-   public static final String NAME = "StringComparison";
-   private static final String REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE = "REGEXP_CONTAINS at line %d. Prefer LIKE when the full power of regex is not needed (e.g. wildcard matching).";
-   private static final String REGEXP_CONTAINS_FUN_ID_STR = "regexp_contains";
-   private static final String REGEX_STRING = "['\"]\\.\\*.*\\.\\*['\"]";
-   private ArrayList<String> result = new ArrayList<String>();
-   private String query;
- 
-   public String getResult() {
-     return result.stream().distinct().collect(Collectors.joining("\n"));
-   }
- 
-   public IdentifyRegexpContainsVisitor(String query) {
-     this.query = query;
-   }
- 
-   @Override
-   public void visit(ASTNodes.ASTFunctionCall node) {
-     ImmutableList<ASTNodes.ASTIdentifier> identifiers = node.getFunction().getNames();
-     for (ASTNodes.ASTIdentifier identifier : identifiers) {
-       // search for regexp_contains
-       if (identifier.getIdString().toLowerCase().equals(REGEXP_CONTAINS_FUN_ID_STR)) {
-         ImmutableList<ASTNodes.ASTExpression> arguments = node.getArguments();
-         // search for argument with string
-         for (ASTNodes.ASTExpression argument : arguments) {
-           if (argument instanceof ASTNodes.ASTStringLiteral) {
-             String stringLiteralArg = ((ASTNodes.ASTStringLiteral) argument).getStringValue();
-             Pattern pattern = Pattern.compile(REGEX_STRING);
-             Matcher matcher = pattern.matcher(stringLiteralArg);
-             if (matcher.find()) {
-               int lineNum = ZetaSQLStringParsingHelper.countLine(
-                   query, identifier.getParseLocationRange().start());
-               result.add(String.format(REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE, lineNum));
-             }
-           }
-         }
-       }
-     }
-   }
- 
-   @Override
-   public String getName() {
-     return NAME;
-   }
- }
+  public static final String NAME = "StringComparison";
+  private static final String REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE = "REGEXP_CONTAINS at line %d. Prefer LIKE when the full power of regex is not needed (e.g. wildcard matching).";
+  private static final String REGEXP_CONTAINS_FUN_ID_STR = "regexp_contains";
+  private static final String REGEX_STRING = "['\"]\\.\\*.*\\.\\*['\"]";
+  private ArrayList<String> result = new ArrayList<String>();
+  private String query;
+
+  public String getResult() {
+    return result.stream().distinct().collect(Collectors.joining("\n"));
+  }
+
+  public IdentifyRegexpContainsVisitor(String query) {
+    this.query = query;
+  }
+
+  @Override
+  public void visit(ASTNodes.ASTFunctionCall node) {
+    ImmutableList<ASTNodes.ASTIdentifier> identifiers = node.getFunction().getNames();
+    for (ASTNodes.ASTIdentifier identifier : identifiers) {
+      // search for regexp_contains
+      if (identifier.getIdString().toLowerCase().equals(REGEXP_CONTAINS_FUN_ID_STR)) {
+        ImmutableList<ASTNodes.ASTExpression> arguments = node.getArguments();
+        // search for argument with string
+        for (ASTNodes.ASTExpression argument : arguments) {
+          if (argument instanceof ASTNodes.ASTStringLiteral) {
+            String stringLiteralArg = ((ASTNodes.ASTStringLiteral) argument).getStringValue();
+            Pattern pattern = Pattern.compile(REGEX_STRING);
+            Matcher matcher = pattern.matcher(stringLiteralArg);
+            if (matcher.find()) {
+              int lineNum = ZetaSQLStringParsingHelper.countLine(
+                  query, identifier.getParseLocationRange().start());
+              result.add(String.format(REGEXP_CONTAINS_ANTI_PATTERN_MESSAGE, lineNum));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}
  

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
@@ -1,177 +1,176 @@
 /*
  * Copyright (C) 2024 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
  */
 
-package com.google.zetasql.toolkit.antipattern.util;
+ package com.google.zetasql.toolkit.antipattern.util;
 
-import com.google.zetasql.AnalyzerOptions;
-import com.google.zetasql.LanguageOptions;
-import com.google.zetasql.Parser;
-import com.google.zetasql.parser.ASTNodes;
-import com.google.zetasql.parser.ParseTreeVisitor;
-import com.google.zetasql.resolvedast.ResolvedNodes;
-import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
-import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
-import com.google.zetasql.toolkit.antipattern.analyzer.visitors.joinorder.JoinOrderVisitor;
-import com.google.zetasql.toolkit.antipattern.cmd.InputQuery;
-import com.google.zetasql.toolkit.antipattern.parser.visitors.*;
-import com.google.zetasql.toolkit.antipattern.parser.visitors.rownum.IdentifyLatestRecordVisitor;
-import com.google.zetasql.toolkit.antipattern.parser.visitors.whereorder.IdentifyWhereOrderVisitor;
-import com.google.zetasql.toolkit.catalog.bigquery.BigQueryAPIResourceProvider;
-import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
-import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
-import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
-
-public class AntiPatternHelper {
-    private static final Logger logger = LoggerFactory.getLogger(AntiPatternHelper.class);
-    private String analyzerProject = null;
-    private BigQueryAPIResourceProvider resourceProvider;
-    private ZetaSQLToolkitAnalyzer analyzer;
-    private HashMap<String, Integer> visitorMetricsMap;
-    private AnalyzerOptions analyzerOptions;
-    private final BigQueryService service;
-    private final String project;
-    private final LanguageOptions languageOptions;
-    private final Boolean useAnalizer;
-    public AntiPatternHelper(String project, Boolean useAnalizer) {
-        this.project = project;
-        this.useAnalizer = useAnalizer;
-
-        this.languageOptions = new LanguageOptions();
-        languageOptions.enableMaximumLanguageFeatures();
-        languageOptions.setSupportsAllStatementKinds();
-        languageOptions.enableReservableKeyword("QUALIFY");
-
-        if (useAnalizer) {
-            this.analyzerOptions = new AnalyzerOptions();
-            this.analyzer = getAnalyzer(this.analyzerOptions);
-            this.service = BigQueryService.buildDefault();
-            this.resourceProvider = BigQueryAPIResourceProvider.build(service);
-        } else {
-            this.service = null;
-        }
-    }
-
-    public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
-        List<AntiPatternVisitor> parserVisitorList = getParserVisitorList(inputQuery.getQuery());
-
-        checkForAntiPatternsInQueryWithParserVisitors(inputQuery, visitorsThatFoundAntiPatterns, parserVisitorList);
-    }
-
-    public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns, List<AntiPatternVisitor> parserVisitorList) {
-        if(this.visitorMetricsMap == null) {
-            setVisitorMetricsMap(parserVisitorList);
-        }
-
-        for (AntiPatternVisitor visitorThatFoundAntiPattern : parserVisitorList) {
-            logger.info("Parsing query with id: " + inputQuery.getQueryId() +
-                    " for anti-pattern: " + visitorThatFoundAntiPattern.getName());
-            ASTNodes.ASTScript parsedQuery = Parser.parseScript( inputQuery.getQuery(), this.languageOptions);
-            try{
-                parsedQuery.accept((ParseTreeVisitor) visitorThatFoundAntiPattern);
-                String result = visitorThatFoundAntiPattern.getResult();
-                if(result.length() > 0) {
-                    visitorsThatFoundAntiPatterns.add(visitorThatFoundAntiPattern);
-                    this.visitorMetricsMap.merge(visitorThatFoundAntiPattern.getName(), 1, Integer::sum);
-                }
-            } catch (Exception e) {
-                logger.error("Error parsing query with id: " + inputQuery.getQueryId() +
-                        " for anti-pattern:" + visitorThatFoundAntiPattern.getName());
-                logger.error(e.getMessage(), e);
-            }
-        }
-    }
-
-    public void checkForAntiPatternsInQueryWithAnalyzerVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
-        String query = inputQuery.getQuery();
-        String currentProject;
-
-        if (inputQuery.getProjectId() == null) {
-            currentProject = this.project;
-        } else {
-            currentProject = inputQuery.getProjectId();
-        }
-
-        BigQueryCatalog catalog = new BigQueryCatalog("");
-        if ((this.analyzerProject == null || !this.analyzerProject.equals(currentProject))) {
-            this.analyzerProject = inputQuery.getProjectId();
-            catalog = new BigQueryCatalog(this.analyzerProject, this.resourceProvider);
-            catalog.addAllTablesUsedInQuery(query, this.analyzerOptions);
-        }
-        JoinOrderVisitor visitor = new JoinOrderVisitor(this.service);
-        if(this.visitorMetricsMap.get(visitor.getName()) == null) {
-            this.visitorMetricsMap.put(visitor.getName(), 0);
-            this.visitorMetricsMap.merge(visitor.getName(), 1, Integer::sum);
-        }
-        try {
-            logger.info("Analyzing query with id: " + inputQuery.getQueryId() +
-                    " For anti-pattern:" + visitor.getName());
-            Iterator<ResolvedNodes.ResolvedStatement> statementIterator = this.analyzer.analyzeStatements(query, catalog);
-            statementIterator.forEachRemaining(statement -> statement.accept(visitor));
-
-            String result = visitor.getResult();
-            if (result.length() > 0) {
-                visitorsThatFoundAntiPatterns.add(visitor);
-            }
-        } catch (Exception e) {
-            logger.error("Error analyzing query with id: " + inputQuery.getQueryId() +
-                    " For anti-pattern:" + visitor.getName());
-            logger.error(e.getMessage(), e);
-        }
-    }
-
-    // THE ORDER HERE MATTERS
-    // this is also the order in which the rewrites get applied
-    public List<AntiPatternVisitor> getParserVisitorList(String query) {
-        return new ArrayList<>(Arrays.asList(
-                new IdentifySimpleSelectStarVisitor(),
-                new IdentifyInSubqueryWithoutAggVisitor(query),
-                new IdentifyDynamicPredicateVisitor(query),
-                new IdentifyOrderByWithoutLimitVisitor(query),
-                new IdentifyRegexpContainsVisitor(query),
-                new IdentifyCTEsEvalMultipleTimesVisitor(query),
-                new IdentifyLatestRecordVisitor(query),
-                new IdentifyWhereOrderVisitor(query),
-                new IdentifyMissingDropStatementVisitor(query),
-                new IdentifyDroppedPersistentTableVisitor(query)
-
-        ));
-    }
-
-    public String getProject() {
-        return project;
-    }
-
-    public Boolean getUseAnalizer() {
-        return useAnalizer;
-    }
-
-    private void setVisitorMetricsMap(List<AntiPatternVisitor> parserVisitorList ) {
-        this.visitorMetricsMap = new HashMap<>();
-        parserVisitorList.stream().forEach(visitor -> this.visitorMetricsMap.put(visitor.getName(), 0));
-    }
-
-    private ZetaSQLToolkitAnalyzer getAnalyzer(AnalyzerOptions options) {
-        LanguageOptions languageOptions = BigQueryLanguageOptions.get().enableMaximumLanguageFeatures();
-        languageOptions.setSupportsAllStatementKinds();
-        options.setLanguageOptions(languageOptions);
-        options.setCreateNewColumnForEachProjectedOutput(true);
-        return new ZetaSQLToolkitAnalyzer(options);
-    }
-}
+ import com.google.zetasql.AnalyzerOptions;
+ import com.google.zetasql.LanguageOptions;
+ import com.google.zetasql.Parser;
+ import com.google.zetasql.parser.ASTNodes;
+ import com.google.zetasql.parser.ParseTreeVisitor;
+ import com.google.zetasql.toolkit.AnalyzedStatement;
+ import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
+ import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
+ import com.google.zetasql.toolkit.antipattern.parser.visitors.*;
+ import com.google.zetasql.toolkit.antipattern.parser.visitors.rownum.IdentifyLatestRecordVisitor;
+ import com.google.zetasql.toolkit.antipattern.parser.visitors.whereorder.IdentifyWhereOrderVisitor;
+ import com.google.zetasql.toolkit.antipattern.analyzer.visitors.joinorder.JoinOrderVisitor;
+ import com.google.zetasql.toolkit.antipattern.cmd.InputQuery;
+ import com.google.zetasql.toolkit.catalog.bigquery.BigQueryAPIResourceProvider;
+ import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
+ import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
+ import java.util.*;
+ 
+ public class AntiPatternHelper {
+     private static final Logger logger = LoggerFactory.getLogger(AntiPatternHelper.class);
+     private String analyzerProject = null;
+     private BigQueryAPIResourceProvider resourceProvider;
+     private ZetaSQLToolkitAnalyzer analyzer;
+     private HashMap<String, Integer> visitorMetricsMap;
+     private AnalyzerOptions analyzerOptions;
+     private final BigQueryService service;
+     private final String project;
+     private final LanguageOptions languageOptions;
+     private final Boolean useAnalizer;
+ 
+     public AntiPatternHelper(String project, Boolean useAnalizer) {
+         this.project = project;
+         this.useAnalizer = useAnalizer;
+ 
+         this.languageOptions = new LanguageOptions();
+         languageOptions.enableMaximumLanguageFeatures();
+         languageOptions.setSupportsAllStatementKinds();
+         languageOptions.enableReservableKeyword("QUALIFY");
+ 
+         if (useAnalizer) {
+             this.analyzerOptions = new AnalyzerOptions();
+             this.analyzer = getAnalyzer(this.analyzerOptions);
+             this.service = BigQueryService.buildDefault();
+             this.resourceProvider = BigQueryAPIResourceProvider.build(service);
+         } else {
+             this.service = null;
+         }
+     }
+ 
+     public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
+         List<AntiPatternVisitor> parserVisitorList = getParserVisitorList(inputQuery.getQuery());
+ 
+         checkForAntiPatternsInQueryWithParserVisitors(inputQuery, visitorsThatFoundAntiPatterns, parserVisitorList);
+     }
+ 
+     public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns, List<AntiPatternVisitor> parserVisitorList) {
+         if (this.visitorMetricsMap == null) {
+             setVisitorMetricsMap(parserVisitorList);
+         }
+ 
+         for (AntiPatternVisitor visitorThatFoundAntiPattern : parserVisitorList) {
+             logger.info("Parsing query with id: " + inputQuery.getQueryId() +
+                     " for anti-pattern: " + visitorThatFoundAntiPattern.getName());
+             ASTNodes.ASTScript parsedQuery = Parser.parseScript(inputQuery.getQuery(), this.languageOptions);
+             try {
+                 parsedQuery.accept((ParseTreeVisitor) visitorThatFoundAntiPattern);
+                 String result = visitorThatFoundAntiPattern.getResult();
+                 if (result.length() > 0) {
+                     visitorsThatFoundAntiPatterns.add(visitorThatFoundAntiPattern);
+                     this.visitorMetricsMap.merge(visitorThatFoundAntiPattern.getName(), 1, Integer::sum);
+                 }
+             } catch (Exception e) {
+                 logger.error("Error parsing query with id: " + inputQuery.getQueryId() +
+                         " for anti-pattern:" + visitorThatFoundAntiPattern.getName());
+                 logger.error(e.getMessage(), e);
+             }
+         }
+     }
+ 
+     public void checkForAntiPatternsInQueryWithAnalyzerVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
+         String query = inputQuery.getQuery();
+         String currentProject;
+ 
+         if (inputQuery.getProjectId() == null) {
+             currentProject = this.project;
+         } else {
+             currentProject = inputQuery.getProjectId();
+         }
+ 
+         BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("");
+         if ((this.analyzerProject == null || !this.analyzerProject.equals(currentProject))) {
+             this.analyzerProject = inputQuery.getProjectId();
+             catalog = new BigQueryCatalog(this.analyzerProject, this.resourceProvider);
+             catalog.addAllTablesUsedInQuery(query, this.analyzerOptions);
+         }
+         JoinOrderVisitor visitor = new JoinOrderVisitor(this.service);
+         if (this.visitorMetricsMap == null) {
+             this.visitorMetricsMap = new HashMap<>();
+         }
+         this.visitorMetricsMap.merge(visitor.getName(), 1, Integer::sum);
+         try {
+             logger.info("Analyzing query with id: " + inputQuery.getQueryId() +
+                     " For anti-pattern:" + visitor.getName());
+             Iterator<AnalyzedStatement> statementIterator = this.analyzer.analyzeStatements(query, catalog);
+             statementIterator.forEachRemaining(statement -> statement.getResolvedStatement().get().accept(visitor));
+ 
+             String result = visitor.getResult();
+             if (result.length() > 0) {
+                 visitorsThatFoundAntiPatterns.add(visitor);
+             }
+         } catch (Exception e) {
+             logger.error("Error analyzing query with id: " + inputQuery.getQueryId() +
+                     " For anti-pattern:" + visitor.getName());
+             logger.error(e.getMessage(), e);
+         }
+     }
+ 
+     // THE ORDER HERE MATTERS
+     // this is also the order in which the rewrites get applied
+     public List<AntiPatternVisitor> getParserVisitorList(String query) {
+         return new ArrayList<>(Arrays.asList(
+                 new IdentifySimpleSelectStarVisitor(),
+                 new IdentifyInSubqueryWithoutAggVisitor(query),
+                 new IdentifyDynamicPredicateVisitor(query),
+                 new IdentifyOrderByWithoutLimitVisitor(query),
+                 new IdentifyRegexpContainsVisitor(query),
+                 new IdentifyCTEsEvalMultipleTimesVisitor(query),
+                 new IdentifyLatestRecordVisitor(query),
+                 new IdentifyWhereOrderVisitor(query),
+                 new IdentifyMissingDropStatementVisitor(query),
+                 new IdentifyDroppedPersistentTableVisitor(query)
+         ));
+     }
+ 
+     public String getProject() {
+         return project;
+     }
+ 
+     public Boolean getUseAnalizer() {
+         return useAnalizer;
+     }
+ 
+     private void setVisitorMetricsMap(List<AntiPatternVisitor> parserVisitorList) {
+         this.visitorMetricsMap = new HashMap<>();
+         parserVisitorList.forEach(visitor -> this.visitorMetricsMap.put(visitor.getName(), 0));
+     }
+ 
+     private ZetaSQLToolkitAnalyzer getAnalyzer(AnalyzerOptions options) {
+         options.setLanguageOptions(this.languageOptions);
+         options.setCreateNewColumnForEachProjectedOutput(true);
+         return new ZetaSQLToolkitAnalyzer(options);
+     }
+ }
+ 

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
@@ -1,21 +1,22 @@
 /*
-* Copyright (C) 2024 Google LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package com.google.zetasql.toolkit.antipattern.util;
+
 import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.LanguageOptions;
 import com.google.zetasql.Parser;
@@ -172,4 +173,3 @@ public class AntiPatternHelper {
         return new ZetaSQLToolkitAnalyzer(options);
     }
 }
- 

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/AntiPatternHelper.java
@@ -1,176 +1,175 @@
 /*
- * Copyright (C) 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
+* Copyright (C) 2024 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
 
- package com.google.zetasql.toolkit.antipattern.util;
+package com.google.zetasql.toolkit.antipattern.util;
+import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.Parser;
+import com.google.zetasql.parser.ASTNodes;
+import com.google.zetasql.parser.ParseTreeVisitor;
+import com.google.zetasql.toolkit.AnalyzedStatement;
+import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
+import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
+import com.google.zetasql.toolkit.antipattern.parser.visitors.*;
+import com.google.zetasql.toolkit.antipattern.parser.visitors.rownum.IdentifyLatestRecordVisitor;
+import com.google.zetasql.toolkit.antipattern.parser.visitors.whereorder.IdentifyWhereOrderVisitor;
+import com.google.zetasql.toolkit.antipattern.analyzer.visitors.joinorder.JoinOrderVisitor;
+import com.google.zetasql.toolkit.antipattern.cmd.InputQuery;
+import com.google.zetasql.toolkit.catalog.bigquery.BigQueryAPIResourceProvider;
+import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
+import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
- import com.google.zetasql.AnalyzerOptions;
- import com.google.zetasql.LanguageOptions;
- import com.google.zetasql.Parser;
- import com.google.zetasql.parser.ASTNodes;
- import com.google.zetasql.parser.ParseTreeVisitor;
- import com.google.zetasql.toolkit.AnalyzedStatement;
- import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
- import com.google.zetasql.toolkit.antipattern.AntiPatternVisitor;
- import com.google.zetasql.toolkit.antipattern.parser.visitors.*;
- import com.google.zetasql.toolkit.antipattern.parser.visitors.rownum.IdentifyLatestRecordVisitor;
- import com.google.zetasql.toolkit.antipattern.parser.visitors.whereorder.IdentifyWhereOrderVisitor;
- import com.google.zetasql.toolkit.antipattern.analyzer.visitors.joinorder.JoinOrderVisitor;
- import com.google.zetasql.toolkit.antipattern.cmd.InputQuery;
- import com.google.zetasql.toolkit.catalog.bigquery.BigQueryAPIResourceProvider;
- import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
- import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
- import org.slf4j.Logger;
- import org.slf4j.LoggerFactory;
- 
- import java.util.*;
- 
- public class AntiPatternHelper {
-     private static final Logger logger = LoggerFactory.getLogger(AntiPatternHelper.class);
-     private String analyzerProject = null;
-     private BigQueryAPIResourceProvider resourceProvider;
-     private ZetaSQLToolkitAnalyzer analyzer;
-     private HashMap<String, Integer> visitorMetricsMap;
-     private AnalyzerOptions analyzerOptions;
-     private final BigQueryService service;
-     private final String project;
-     private final LanguageOptions languageOptions;
-     private final Boolean useAnalizer;
- 
-     public AntiPatternHelper(String project, Boolean useAnalizer) {
-         this.project = project;
-         this.useAnalizer = useAnalizer;
- 
-         this.languageOptions = new LanguageOptions();
-         languageOptions.enableMaximumLanguageFeatures();
-         languageOptions.setSupportsAllStatementKinds();
-         languageOptions.enableReservableKeyword("QUALIFY");
- 
-         if (useAnalizer) {
-             this.analyzerOptions = new AnalyzerOptions();
-             this.analyzer = getAnalyzer(this.analyzerOptions);
-             this.service = BigQueryService.buildDefault();
-             this.resourceProvider = BigQueryAPIResourceProvider.build(service);
-         } else {
-             this.service = null;
-         }
-     }
- 
-     public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
-         List<AntiPatternVisitor> parserVisitorList = getParserVisitorList(inputQuery.getQuery());
- 
-         checkForAntiPatternsInQueryWithParserVisitors(inputQuery, visitorsThatFoundAntiPatterns, parserVisitorList);
-     }
- 
-     public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns, List<AntiPatternVisitor> parserVisitorList) {
-         if (this.visitorMetricsMap == null) {
-             setVisitorMetricsMap(parserVisitorList);
-         }
- 
-         for (AntiPatternVisitor visitorThatFoundAntiPattern : parserVisitorList) {
-             logger.info("Parsing query with id: " + inputQuery.getQueryId() +
-                     " for anti-pattern: " + visitorThatFoundAntiPattern.getName());
-             ASTNodes.ASTScript parsedQuery = Parser.parseScript(inputQuery.getQuery(), this.languageOptions);
-             try {
-                 parsedQuery.accept((ParseTreeVisitor) visitorThatFoundAntiPattern);
-                 String result = visitorThatFoundAntiPattern.getResult();
-                 if (result.length() > 0) {
-                     visitorsThatFoundAntiPatterns.add(visitorThatFoundAntiPattern);
-                     this.visitorMetricsMap.merge(visitorThatFoundAntiPattern.getName(), 1, Integer::sum);
-                 }
-             } catch (Exception e) {
-                 logger.error("Error parsing query with id: " + inputQuery.getQueryId() +
-                         " for anti-pattern:" + visitorThatFoundAntiPattern.getName());
-                 logger.error(e.getMessage(), e);
-             }
-         }
-     }
- 
-     public void checkForAntiPatternsInQueryWithAnalyzerVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
-         String query = inputQuery.getQuery();
-         String currentProject;
- 
-         if (inputQuery.getProjectId() == null) {
-             currentProject = this.project;
-         } else {
-             currentProject = inputQuery.getProjectId();
-         }
- 
-         BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("");
-         if ((this.analyzerProject == null || !this.analyzerProject.equals(currentProject))) {
-             this.analyzerProject = inputQuery.getProjectId();
-             catalog = new BigQueryCatalog(this.analyzerProject, this.resourceProvider);
-             catalog.addAllTablesUsedInQuery(query, this.analyzerOptions);
-         }
-         JoinOrderVisitor visitor = new JoinOrderVisitor(this.service);
-         if (this.visitorMetricsMap == null) {
-             this.visitorMetricsMap = new HashMap<>();
-         }
-         this.visitorMetricsMap.merge(visitor.getName(), 1, Integer::sum);
-         try {
-             logger.info("Analyzing query with id: " + inputQuery.getQueryId() +
-                     " For anti-pattern:" + visitor.getName());
-             Iterator<AnalyzedStatement> statementIterator = this.analyzer.analyzeStatements(query, catalog);
-             statementIterator.forEachRemaining(statement -> statement.getResolvedStatement().get().accept(visitor));
- 
-             String result = visitor.getResult();
-             if (result.length() > 0) {
-                 visitorsThatFoundAntiPatterns.add(visitor);
-             }
-         } catch (Exception e) {
-             logger.error("Error analyzing query with id: " + inputQuery.getQueryId() +
-                     " For anti-pattern:" + visitor.getName());
-             logger.error(e.getMessage(), e);
-         }
-     }
- 
-     // THE ORDER HERE MATTERS
-     // this is also the order in which the rewrites get applied
-     public List<AntiPatternVisitor> getParserVisitorList(String query) {
-         return new ArrayList<>(Arrays.asList(
-                 new IdentifySimpleSelectStarVisitor(),
-                 new IdentifyInSubqueryWithoutAggVisitor(query),
-                 new IdentifyDynamicPredicateVisitor(query),
-                 new IdentifyOrderByWithoutLimitVisitor(query),
-                 new IdentifyRegexpContainsVisitor(query),
-                 new IdentifyCTEsEvalMultipleTimesVisitor(query),
-                 new IdentifyLatestRecordVisitor(query),
-                 new IdentifyWhereOrderVisitor(query),
-                 new IdentifyMissingDropStatementVisitor(query),
-                 new IdentifyDroppedPersistentTableVisitor(query)
-         ));
-     }
- 
-     public String getProject() {
-         return project;
-     }
- 
-     public Boolean getUseAnalizer() {
-         return useAnalizer;
-     }
- 
-     private void setVisitorMetricsMap(List<AntiPatternVisitor> parserVisitorList) {
-         this.visitorMetricsMap = new HashMap<>();
-         parserVisitorList.forEach(visitor -> this.visitorMetricsMap.put(visitor.getName(), 0));
-     }
- 
-     private ZetaSQLToolkitAnalyzer getAnalyzer(AnalyzerOptions options) {
-         options.setLanguageOptions(this.languageOptions);
-         options.setCreateNewColumnForEachProjectedOutput(true);
-         return new ZetaSQLToolkitAnalyzer(options);
-     }
- }
+import java.util.*;
+
+public class AntiPatternHelper {
+    private static final Logger logger = LoggerFactory.getLogger(AntiPatternHelper.class);
+    private String analyzerProject = null;
+    private BigQueryAPIResourceProvider resourceProvider;
+    private ZetaSQLToolkitAnalyzer analyzer;
+    private HashMap<String, Integer> visitorMetricsMap;
+    private AnalyzerOptions analyzerOptions;
+    private final BigQueryService service;
+    private final String project;
+    private final LanguageOptions languageOptions;
+    private final Boolean useAnalizer;
+
+    public AntiPatternHelper(String project, Boolean useAnalizer) {
+        this.project = project;
+        this.useAnalizer = useAnalizer;
+
+        this.languageOptions = new LanguageOptions();
+        languageOptions.enableMaximumLanguageFeatures();
+        languageOptions.setSupportsAllStatementKinds();
+        languageOptions.enableReservableKeyword("QUALIFY");
+
+        if (useAnalizer) {
+            this.analyzerOptions = new AnalyzerOptions();
+            this.analyzer = getAnalyzer(this.analyzerOptions);
+            this.service = BigQueryService.buildDefault();
+            this.resourceProvider = BigQueryAPIResourceProvider.build(service);
+        } else {
+            this.service = null;
+        }
+    }
+
+    public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
+        List<AntiPatternVisitor> parserVisitorList = getParserVisitorList(inputQuery.getQuery());
+
+        checkForAntiPatternsInQueryWithParserVisitors(inputQuery, visitorsThatFoundAntiPatterns, parserVisitorList);
+    }
+
+    public void checkForAntiPatternsInQueryWithParserVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns, List<AntiPatternVisitor> parserVisitorList) {
+        if (this.visitorMetricsMap == null) {
+            setVisitorMetricsMap(parserVisitorList);
+        }
+
+        for (AntiPatternVisitor visitorThatFoundAntiPattern : parserVisitorList) {
+            logger.info("Parsing query with id: " + inputQuery.getQueryId() +
+                    " for anti-pattern: " + visitorThatFoundAntiPattern.getName());
+            ASTNodes.ASTScript parsedQuery = Parser.parseScript(inputQuery.getQuery(), this.languageOptions);
+            try {
+                parsedQuery.accept((ParseTreeVisitor) visitorThatFoundAntiPattern);
+                String result = visitorThatFoundAntiPattern.getResult();
+                if (result.length() > 0) {
+                    visitorsThatFoundAntiPatterns.add(visitorThatFoundAntiPattern);
+                    this.visitorMetricsMap.merge(visitorThatFoundAntiPattern.getName(), 1, Integer::sum);
+                }
+            } catch (Exception e) {
+                logger.error("Error parsing query with id: " + inputQuery.getQueryId() +
+                        " for anti-pattern:" + visitorThatFoundAntiPattern.getName());
+                logger.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    public void checkForAntiPatternsInQueryWithAnalyzerVisitors(InputQuery inputQuery, List<AntiPatternVisitor> visitorsThatFoundAntiPatterns) {
+        String query = inputQuery.getQuery();
+        String currentProject;
+
+        if (inputQuery.getProjectId() == null) {
+            currentProject = this.project;
+        } else {
+            currentProject = inputQuery.getProjectId();
+        }
+
+        BigQueryCatalog catalog = BigQueryCatalog.usingBigQueryAPI("");
+        if ((this.analyzerProject == null || !this.analyzerProject.equals(currentProject))) {
+            this.analyzerProject = inputQuery.getProjectId();
+            catalog = new BigQueryCatalog(this.analyzerProject, this.resourceProvider);
+            catalog.addAllTablesUsedInQuery(query, this.analyzerOptions);
+        }
+        JoinOrderVisitor visitor = new JoinOrderVisitor(this.service);
+        if (this.visitorMetricsMap == null) {
+            this.visitorMetricsMap = new HashMap<>();
+        }
+        this.visitorMetricsMap.merge(visitor.getName(), 1, Integer::sum);
+        try {
+            logger.info("Analyzing query with id: " + inputQuery.getQueryId() +
+                    " For anti-pattern:" + visitor.getName());
+            Iterator<AnalyzedStatement> statementIterator = this.analyzer.analyzeStatements(query, catalog);
+            statementIterator.forEachRemaining(statement -> statement.getResolvedStatement().get().accept(visitor));
+
+            String result = visitor.getResult();
+            if (result.length() > 0) {
+                visitorsThatFoundAntiPatterns.add(visitor);
+            }
+        } catch (Exception e) {
+            logger.error("Error analyzing query with id: " + inputQuery.getQueryId() +
+                    " For anti-pattern:" + visitor.getName());
+            logger.error(e.getMessage(), e);
+        }
+    }
+
+    // THE ORDER HERE MATTERS
+    // this is also the order in which the rewrites get applied
+    public List<AntiPatternVisitor> getParserVisitorList(String query) {
+        return new ArrayList<>(Arrays.asList(
+                new IdentifySimpleSelectStarVisitor(),
+                new IdentifyInSubqueryWithoutAggVisitor(query),
+                new IdentifyDynamicPredicateVisitor(query),
+                new IdentifyOrderByWithoutLimitVisitor(query),
+                new IdentifyRegexpContainsVisitor(query),
+                new IdentifyCTEsEvalMultipleTimesVisitor(query),
+                new IdentifyLatestRecordVisitor(query),
+                new IdentifyWhereOrderVisitor(query),
+                new IdentifyMissingDropStatementVisitor(query),
+                new IdentifyDroppedPersistentTableVisitor(query)
+        ));
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public Boolean getUseAnalizer() {
+        return useAnalizer;
+    }
+
+    private void setVisitorMetricsMap(List<AntiPatternVisitor> parserVisitorList) {
+        this.visitorMetricsMap = new HashMap<>();
+        parserVisitorList.forEach(visitor -> this.visitorMetricsMap.put(visitor.getName(), 0));
+    }
+
+    private ZetaSQLToolkitAnalyzer getAnalyzer(AnalyzerOptions options) {
+        options.setLanguageOptions(this.languageOptions);
+        options.setCreateNewColumnForEachProjectedOutput(true);
+        return new ZetaSQLToolkitAnalyzer(options);
+    }
+}
  

--- a/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/PrintAnalyzerDebugString.java
+++ b/bigquery-antipattern-recognition/src/main/java/com/google/zetasql/toolkit/antipattern/util/PrintAnalyzerDebugString.java
@@ -3,6 +3,7 @@ package com.google.zetasql.toolkit.antipattern.util;
 import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.LanguageOptions;
 import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedStatement;
+import com.google.zetasql.toolkit.AnalyzedStatement;
 import com.google.zetasql.toolkit.ZetaSQLToolkitAnalyzer;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryCatalog;
 import com.google.zetasql.toolkit.catalog.bigquery.BigQueryService;
@@ -69,7 +70,7 @@ public class PrintAnalyzerDebugString {
         + ";";
 
     catalog.addAllTablesUsedInQuery(query, options);
-    Iterator<ResolvedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
+    Iterator<AnalyzedStatement> statementIterator = analyzer.analyzeStatements(query, catalog);
     statementIterator.forEachRemaining(System.out::println);
 
   }


### PR DESCRIPTION
Resolves #101 
This pull request includes updates to dependencies, code refactoring for improved readability and maintainability, and minor formatting changes. The most important changes involve dependency version upgrades, refactoring of visitor logic, and adjustments to the analyzer for BigQuery anti-pattern detection.

### Dependency Updates:
* Updated `zetasql-toolkit-core` to `zetasql-toolkit-bigquery` and upgraded its version from `0.3.3` to `0.5.1` in the `pom.xml` file.
* Upgraded `zetasql-client` version from `2023.04.1` to `2024.03.1`.
* Updated `libraries-bom` version from `26.15.0` to `26.43.0`.

### Code Refactoring:
* Simplified the handling of visitor metrics in `AntiPatternHelper` by initializing the `visitorMetricsMap` only when necessary and refactored the `getAnalyzer` method to use preconfigured `languageOptions`. [[1]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dL111-R127) [[2]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dL167-R176)
* Updated the `REGEXP_CONTAINS` anti-pattern detection logic in `IdentifyRegexpContainsVisitor` to use `getStringValue()` instead of `getImage()` for string literals and adjusted indentation for consistency.
* Replaced `ResolvedStatement` with `AnalyzedStatement` in the analyzer logic for better alignment with the updated ZetaSQL toolkit API. [[1]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dL111-R127) [[2]](diffhunk://#diff-989acf321946b3469167b6eda25cd6b395a00ed5db52e30cfcfe9f6cbeb9529cL72-R73)

### Formatting and Minor Adjustments:
* Removed unused imports and reordered others for clarity in multiple files, including `IdentifyRegexpContainsVisitor` and `AntiPatternHelper`. [[1]](diffhunk://#diff-2fa31a32e764b77f6015a31608a7a917cfe648e68e1975586aa4ad9d7c783426L21) [[2]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dL24-L35)
* Added or adjusted blank lines for better readability in `AntiPatternHelper` and other files. [[1]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dR52) [[2]](diffhunk://#diff-08b5e60cf089d3a2f2b01aaf227965b4fe44e996882bab88c0f26abe5f1da98dL153)