### PR TITLE
fix: replace deprecated openjdk:11 with eclipse-temurin:11-jre

### DIFF
--- a/bigquery-antipattern-recognition/pom.xml
+++ b/bigquery-antipattern-recognition/pom.xml
@@ -161,7 +161,7 @@ limitations under the License.
                         </mainClass>
                     </container>
                     <from>
-                        <image>openjdk:11</image>
+                        <image>eclipse-temurin:11-jre</image>
                     </from>
                     <to>
                         <image>bigquery-antipattern-recognition</image>


### PR DESCRIPTION
 The `openjdk:11` image has been deprecated and removed from Docker Hub.